### PR TITLE
Add codex environment setup script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,15 @@ goreleaser build --snapshot --clean
 golangci-lint run
 ```
 
+### Codex environment setup script
+
+To install all dependencies in one step you can run the provided script. Execute
+it from the repository root:
+
+```bash
+./scripts/setup_codex_environment.sh
+```
+
 ### Local NetBird setup
 
 > **IMPORTANT**: All the steps below have to get executed at least once to get the development setup up and running!

--- a/scripts/setup_codex_environment.sh
+++ b/scripts/setup_codex_environment.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This script installs dependencies to replicate the Codex environment
+# for building and testing NetBird.
+
+set -e
+
+# Versions
+GO_VERSION="1.21.0"
+GORELEASER_VER="v2.3.2"
+
+# Update package lists and install system dependencies
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+    curl wget git build-essential gettext-base iptables \
+    libgl1-mesa-dev xorg-dev libayatana-appindicator3-dev docker.io docker-compose
+
+# Install Go
+if ! go version | grep -q "$GO_VERSION"; then
+    wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz
+    sudo rm -rf /usr/local/go
+    sudo tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
+    rm go${GO_VERSION}.linux-amd64.tar.gz
+fi
+export PATH=$PATH:/usr/local/go/bin
+
+# Install gRPC tools
+GO_BIN=$(go env GOPATH)/bin
+[ -d "$GO_BIN" ] || mkdir -p "$GO_BIN"
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+# Install goreleaser
+curl -sL https://git.io/goreleaser | bash -s -- -b "$GO_BIN" "$GORELEASER_VER"
+
+# Install golangci-lint
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$GO_BIN" latest
+
+# Run go mod tidy if executed in repository root
+if [ -f go.mod ]; then
+    go mod tidy
+fi
+
+cat <<'MSG'
+Environment setup complete. Ensure $GOPATH/bin is in your PATH to use installed tools.
+MSG
+
+


### PR DESCRIPTION
## Summary
- add script `setup_codex_environment.sh` for installing build dependencies
- document the script in `CONTRIBUTING.md`

## Testing
- `bash -n scripts/setup_codex_environment.sh`
- `go test ./base62`


------
https://chatgpt.com/codex/tasks/task_e_6841b4701d188324923f29f4038d47b3