### PR TITLE
Fix upload URL path generation

### DIFF
--- a/upload-server/server/local.go
+++ b/upload-server/server/local.go
@@ -78,8 +78,8 @@ func (l *local) getUploadURL(objectKey string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse upload URL: %w", err)
 	}
-	newURL := parsedUploadURL.JoinPath(parsedUploadURL.Path, putURLPath, objectKey)
-	return newURL.String(), nil
+        newURL := parsedUploadURL.JoinPath(putURLPath, objectKey)
+        return newURL.String(), nil
 }
 
 func (l *local) handlePutRequest(w http.ResponseWriter, r *http.Request) {

--- a/upload-server/server/local_test.go
+++ b/upload-server/server/local_test.go
@@ -40,6 +40,30 @@ func Test_LocalHandlerGetUploadURL(t *testing.T) {
 
 }
 
+func Test_LocalHandlerGetUploadURL_WithPath(t *testing.T) {
+       mockURL := "http://localhost:8080/api"
+       t.Setenv("SERVER_URL", mockURL)
+       t.Setenv("STORE_DIR", t.TempDir())
+
+       mux := http.NewServeMux()
+       err := configureLocalHandlers(mux)
+       require.NoError(t, err)
+
+       req := httptest.NewRequest(http.MethodGet, types.GetURLPath+"?id=testfile", nil)
+       req.Header.Set(types.ClientHeader, types.ClientHeaderValue)
+
+       rec := httptest.NewRecorder()
+       mux.ServeHTTP(rec, req)
+
+       require.Equal(t, http.StatusOK, rec.Code)
+
+       var response types.GetURLResponse
+       err = json.Unmarshal(rec.Body.Bytes(), &response)
+       require.NoError(t, err)
+       expected := "/api" + putURLPath + "/testfile/"
+       require.Contains(t, response.URL, expected)
+}
+
 func Test_LocalHandlePutRequest(t *testing.T) {
 	mockDir := t.TempDir()
 	mockURL := "http://localhost:8080"


### PR DESCRIPTION
## Summary
- avoid duplicate path segments when creating local upload URLs
- test upload URL generation when server path prefix is present

## Testing
- `go test ./upload-server/server -run Local -v`


------
https://chatgpt.com/codex/tasks/task_e_68426b40767883249ea1d34bdc1b6491