### PR TITLE
Default peers require approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ export NETBIRD_DOMAIN=netbird.example.com; curl -fsSL https://github.com/netbird
 ```
 - Once finished, you can manage the resources via `docker-compose`
 
+### Approving peers
+
+By default, newly enrolled peers require approval from an administrator before
+they receive the network configuration. You can approve a peer via the
+management API using the helper script:
+
+```bash
+./scripts/approve_peer.sh <PEER_ID> <API_TOKEN> [API_URL]
+```
+
+`API_URL` defaults to `http://localhost:33073` when omitted.
+
 ### A bit on NetBird internals
 -  Every machine in the network runs [NetBird Agent (or Client)](client/) that manages WireGuard.
 -  Every agent connects to [Management Service](management/) that holds network state, manages peer IPs, and distributes network updates to agents (peers).

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -571,7 +571,7 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, setupKey, userID s
 			Name:                        peer.Meta.Hostname,
 			DNSLabel:                    freeLabel,
 			UserID:                      userID,
-			Status:                      &nbpeer.PeerStatus{Connected: false, LastSeen: registrationTime},
+			Status:                      &nbpeer.PeerStatus{Connected: false, LastSeen: registrationTime, RequiresApproval: true},
 			SSHEnabled:                  false,
 			SSHKey:                      peer.SSHKey,
 			LastLogin:                   &registrationTime,
@@ -669,7 +669,7 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, setupKey, userID s
 		am.BufferUpdateAccountPeers(ctx, accountID)
 	}
 
-	return am.getValidatedPeerWithMap(ctx, false, accountID, newPeer)
+	return am.getValidatedPeerWithMap(ctx, true, accountID, newPeer)
 }
 
 func getFreeIP(ctx context.Context, transaction store.Store, accountID string) (net.IP, error) {

--- a/scripts/approve_peer.sh
+++ b/scripts/approve_peer.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Simple helper to approve a peer using NetBird Management API
+# Usage: ./scripts/approve_peer.sh <PEER_ID> <API_TOKEN> [API_URL]
+# API_URL defaults to http://localhost:33073
+set -euo pipefail
+
+PEER_ID=${1:-}
+TOKEN=${2:-}
+API_URL=${3:-http://localhost:33073}
+
+if [[ -z "$PEER_ID" || -z "$TOKEN" ]]; then
+    echo "Usage: $0 <PEER_ID> <API_TOKEN> [API_URL]" >&2
+    exit 1
+fi
+
+curl -X PUT -H "Authorization: Bearer $TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"approval_required":false}' \
+     "$API_URL/api/peers/$PEER_ID" | jq


### PR DESCRIPTION
## Summary
- set RequiresApproval true for new peers and block network map until approved
- call getValidatedPeerWithMap with approval flag
- document manual approval script
- add helper script to approve peers via API

## Testing
- `go test ./...` *(fails: interrupted)*
- `go vet ./...` *(fails: missing pcap.h)*

------
https://chatgpt.com/codex/tasks/task_e_6841b87d88f48324a3a97597084fa825