### PR TITLE
Add self-hosted CI workflow

### DIFF
--- a/.github/workflows/self-hosted-ci.yml
+++ b/.github/workflows/self-hosted-ci.yml
@@ -1,0 +1,49 @@
+name: Self-Hosted CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.x"
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          args: --timeout=5m
+      - name: gofmt
+        run: |
+          test -z "$(gofmt -l .)" || { gofmt -d $(gofmt -l .); exit 1; }
+  build:
+    name: Build & Test
+    runs-on: self-hosted
+    needs: lint
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.x"
+          cache: false
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on self-hosted runners

## Testing
- `go test ./...` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6842f5d5d1208324afdbf5d106b9d3af