### PR TITLE
Fix peer approval flag update

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -270,6 +270,16 @@ func (am *DefaultAccountManager) UpdatePeer(ctx context.Context, accountID, user
 			inactivityExpirationChanged = true
 		}
 
+		if update.Status != nil {
+			if peer.Status == nil {
+				peer.Status = &nbpeer.PeerStatus{RequiresApproval: update.Status.RequiresApproval}
+				requiresPeerUpdates = true
+			} else if peer.Status.RequiresApproval != update.Status.RequiresApproval {
+				peer.Status.RequiresApproval = update.Status.RequiresApproval
+				requiresPeerUpdates = true
+			}
+		}
+
 		return transaction.SavePeer(ctx, store.LockingStrengthUpdate, accountID, peer)
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- ensure peer approval flag is stored when updating a peer

## Testing
- `go test ./...` *(fails: logger_test.go didn't match any event)*

------
https://chatgpt.com/codex/tasks/task_e_6842f62795bc8324aaedca25e2b1c90c