### PR TITLE
Set RequiresApproval on peer creation

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -588,6 +588,12 @@ func (am *DefaultAccountManager) AddPeer(ctx context.Context, setupKey, userID s
 			return fmt.Errorf("failed to get account settings: %w", err)
 		}
 
+		if settings.Extra != nil && settings.Extra.PeerApprovalEnabled {
+			newPeer.Status.RequiresApproval = true
+		} else {
+			newPeer.Status.RequiresApproval = false
+		}
+
 		opEvent.TargetID = newPeer.ID
 		opEvent.Meta = newPeer.EventMeta(am.GetDNSDomain(settings))
 		if !addedByUser {


### PR DESCRIPTION
## Summary
- set `RequiresApproval` based on account setting when new peer is added

## Testing
- `go test ./...` *(fails: gcc signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6842fe679d9c83248761fbf9bd0462fd