### PR TITLE
Fix YAML syntax in install script workflow

### DIFF
--- a/.github/workflows/install-script-test.yml
+++ b/.github/workflows/install-script-test.yml
@@ -19,7 +19,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         skip_ui_mode: [true, false]
         install_binary: [true, false]
-    runs-on: [self-hosted, ${{ matrix.os }}]
+    runs-on:
+      - self-hosted
+      - ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- fix YAML syntax in install script workflow by expanding `runs-on` into multi-line list

## Testing
- `go test ./...` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6843020f368c8324b558b1b5f873f2bf