### PR TITLE
Fix YAML syntax in golangci-lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -34,7 +34,7 @@ jobs:
           - os: ubuntu-latest
             display_name: Linux
     name: ${{ matrix.display_name }}
-    runs-on: [self-hosted, ${{ matrix.os }}]
+    runs-on: [self-hosted, '${{ matrix.os }}']
     timeout-minutes: 15
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- fix YAML quoting for matrix.os in the golangci-lint workflow

## Testing
- `go test ./...` *(fails: gcc: signal: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6843031038dc8324a63731a8c2848ba7