### PR TITLE
Publish images to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,13 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to Docker hub
+      - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install OS build dependencies
         run: sudo apt update && sudo apt install -y -q gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -148,7 +148,7 @@ nfpms:
       preremove: "release_files/pre_remove.sh"
 dockers:
   - image_templates:
-      - netbirdio/netbird:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-amd64
     ids:
       - netbird
     goarch: amd64
@@ -163,7 +163,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/netbird:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-arm64v8
     ids:
       - netbird
     goarch: arm64
@@ -178,7 +178,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/netbird:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-arm
     ids:
       - netbird
     goarch: arm
@@ -195,7 +195,7 @@ dockers:
       - "--label=maintainer=dev@netbird.io"
 
   - image_templates:
-      - netbirdio/netbird:{{ .Version }}-rootless-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-amd64
     ids:
       - netbird
     goarch: amd64
@@ -209,7 +209,7 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/netbird:{{ .Version }}-rootless-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-arm64v8
     ids:
       - netbird
     goarch: arm64
@@ -223,7 +223,7 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/netbird:{{ .Version }}-rootless-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-arm
     ids:
       - netbird
     goarch: arm
@@ -239,7 +239,7 @@ dockers:
       - "--label=maintainer=dev@netbird.io"
 
   - image_templates:
-      - netbirdio/relay:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-amd64
     ids:
       - netbird-relay
     goarch: amd64
@@ -254,7 +254,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/relay:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-arm64v8
     ids:
       - netbird-relay
     goarch: arm64
@@ -269,7 +269,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/relay:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-arm
     ids:
       - netbird-relay
     goarch: arm
@@ -285,7 +285,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/signal:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-amd64
     ids:
       - netbird-signal
     goarch: amd64
@@ -300,7 +300,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/signal:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-arm64v8
     ids:
       - netbird-signal
     goarch: arm64
@@ -315,7 +315,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/signal:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-arm
     ids:
       - netbird-signal
     goarch: arm
@@ -331,7 +331,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/management:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-amd64
     ids:
       - netbird-mgmt
     goarch: amd64
@@ -346,7 +346,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/management:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-arm64v8
     ids:
       - netbird-mgmt
     goarch: arm64
@@ -361,7 +361,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/management:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-arm
     ids:
       - netbird-mgmt
     goarch: arm
@@ -377,7 +377,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/management:{{ .Version }}-debug-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-debug-amd64
     ids:
       - netbird-mgmt
     goarch: amd64
@@ -392,7 +392,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/management:{{ .Version }}-debug-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-debug-arm64v8
     ids:
       - netbird-mgmt
     goarch: arm64
@@ -408,7 +408,7 @@ dockers:
       - "--label=maintainer=dev@netbird.io"
 
   - image_templates:
-      - netbirdio/management:{{ .Version }}-debug-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-debug-arm
     ids:
       - netbird-mgmt
     goarch: arm
@@ -424,7 +424,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/upload:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-amd64
     ids:
       - netbird-upload
     goarch: amd64
@@ -439,7 +439,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/upload:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-arm64v8
     ids:
       - netbird-upload
     goarch: arm64
@@ -454,7 +454,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
   - image_templates:
-      - netbirdio/upload:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-arm
     ids:
       - netbird-upload
     goarch: arm
@@ -470,82 +470,82 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=maintainer=dev@netbird.io"
 docker_manifests:
-  - name_template: netbirdio/netbird:{{ .Version }}
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}
     image_templates:
-      - netbirdio/netbird:{{ .Version }}-arm64v8
-      - netbirdio/netbird:{{ .Version }}-arm
-      - netbirdio/netbird:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-amd64
 
-  - name_template: netbirdio/netbird:latest
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:latest
     image_templates:
-      - netbirdio/netbird:{{ .Version }}-arm64v8
-      - netbirdio/netbird:{{ .Version }}-arm
-      - netbirdio/netbird:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-amd64
 
-  - name_template: netbirdio/netbird:{{ .Version }}-rootless
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless
     image_templates:
-      - netbirdio/netbird:{{ .Version }}-rootless-arm64v8
-      - netbirdio/netbird:{{ .Version }}-rootless-arm
-      - netbirdio/netbird:{{ .Version }}-rootless-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-amd64
 
-  - name_template: netbirdio/netbird:rootless-latest
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:rootless-latest
     image_templates:
-      - netbirdio/netbird:{{ .Version }}-rootless-arm64v8
-      - netbirdio/netbird:{{ .Version }}-rootless-arm
-      - netbirdio/netbird:{{ .Version }}-rootless-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/netbird:{{ .Version }}-rootless-amd64
 
-  - name_template: netbirdio/relay:{{ .Version }}
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}
     image_templates:
-      - netbirdio/relay:{{ .Version }}-arm64v8
-      - netbirdio/relay:{{ .Version }}-arm
-      - netbirdio/relay:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-amd64
 
-  - name_template: netbirdio/relay:latest
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:latest
     image_templates:
-      - netbirdio/relay:{{ .Version }}-arm64v8
-      - netbirdio/relay:{{ .Version }}-arm
-      - netbirdio/relay:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/relay:{{ .Version }}-amd64
 
-  - name_template: netbirdio/signal:{{ .Version }}
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}
     image_templates:
-      - netbirdio/signal:{{ .Version }}-arm64v8
-      - netbirdio/signal:{{ .Version }}-arm
-      - netbirdio/signal:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-amd64
 
-  - name_template: netbirdio/signal:latest
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:latest
     image_templates:
-      - netbirdio/signal:{{ .Version }}-arm64v8
-      - netbirdio/signal:{{ .Version }}-arm
-      - netbirdio/signal:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/signal:{{ .Version }}-amd64
 
-  - name_template: netbirdio/management:{{ .Version }}
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}
     image_templates:
-      - netbirdio/management:{{ .Version }}-arm64v8
-      - netbirdio/management:{{ .Version }}-arm
-      - netbirdio/management:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-amd64
 
-  - name_template: netbirdio/management:latest
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:latest
     image_templates:
-      - netbirdio/management:{{ .Version }}-arm64v8
-      - netbirdio/management:{{ .Version }}-arm
-      - netbirdio/management:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-amd64
 
-  - name_template: netbirdio/management:debug-latest
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:debug-latest
     image_templates:
-      - netbirdio/management:{{ .Version }}-debug-arm64v8
-      - netbirdio/management:{{ .Version }}-debug-arm
-      - netbirdio/management:{{ .Version }}-debug-amd64
-  - name_template: netbirdio/upload:{{ .Version }}
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-debug-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-debug-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/management:{{ .Version }}-debug-amd64
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}
     image_templates:
-      - netbirdio/upload:{{ .Version }}-arm64v8
-      - netbirdio/upload:{{ .Version }}-arm
-      - netbirdio/upload:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-amd64
 
-  - name_template: netbirdio/upload:latest
+  - name_template: ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:latest
     image_templates:
-      - netbirdio/upload:{{ .Version }}-arm64v8
-      - netbirdio/upload:{{ .Version }}-arm
-      - netbirdio/upload:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-arm64v8
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-arm
+      - ghcr.io/{{ .Env.GITHUB_REPOSITORY_OWNER }}/upload:{{ .Version }}-amd64
 brews:
   - ids:
       - default


### PR DESCRIPTION
## Summary
- publish Docker images to GitHub Container Registry instead of Docker Hub
- infer image repository owner from the local repository URL

## Testing
- `go test ./...` *(failed: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6842fc80a4308324988201f02670bca2