### PR TITLE
Add persistent SQLite store for traffic logs

### DIFF
--- a/client/firewall/uspfilter/conntrack/common_test.go
+++ b/client/firewall/uspfilter/conntrack/common_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var logger = log.NewFromLogrus(logrus.StandardLogger())
-var flowLogger = netflow.NewManager(nil, []byte{}, nil).GetLogger()
+var flowLogger = netflow.NewManager(nil, []byte{}, nil, nil).GetLogger()
 
 // Memory pressure tests
 func BenchmarkMemoryPressure(b *testing.B) {

--- a/client/firewall/uspfilter/uspfilter_test.go
+++ b/client/firewall/uspfilter/uspfilter_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var logger = log.NewFromLogrus(logrus.StandardLogger())
-var flowLogger = netflow.NewManager(nil, []byte{}, nil).GetLogger()
+var flowLogger = netflow.NewManager(nil, []byte{}, nil, nil).GetLogger()
 
 type IFaceMock struct {
 	SetFilterFunc   func(device.PacketFilter) error

--- a/client/internal/acl/manager_test.go
+++ b/client/internal/acl/manager_test.go
@@ -15,7 +15,7 @@ import (
 	mgmProto "github.com/netbirdio/netbird/management/proto"
 )
 
-var flowLogger = netflow.NewManager(nil, []byte{}, nil).GetLogger()
+var flowLogger = netflow.NewManager(nil, []byte{}, nil, nil).GetLogger()
 
 func TestDefaultManager(t *testing.T) {
 	networkMap := &mgmProto.NetworkMap{

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/netbirdio/netbird/management/domain"
 )
 
-var flowLogger = netflow.NewManager(nil, []byte{}, nil).GetLogger()
+var flowLogger = netflow.NewManager(nil, []byte{}, nil, nil).GetLogger()
 
 type mocWGIface struct {
 	filter device.PacketFilter

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -363,7 +363,7 @@ func (e *Engine) Start() error {
 
 	// start flow manager right after interface creation
 	publicKey := e.config.WgPrivateKey.PublicKey()
-	e.flowManager = netflow.NewManager(e.wgInterface, publicKey[:], e.statusRecorder)
+	e.flowManager = netflow.NewManager(e.wgInterface, publicKey[:], e.statusRecorder, e.stateManager)
 
 	if e.config.RosenpassEnabled {
 		log.Infof("rosenpass is enabled")

--- a/client/internal/netflow/logger/logger_test.go
+++ b/client/internal/netflow/logger/logger_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestStore(t *testing.T) {
-	logger := logger.New(nil, netip.Prefix{})
+	logger := logger.New(nil, netip.Prefix{}, nil)
 	logger.Enable()
 
 	event := types.EventFields{

--- a/client/internal/netflow/manager.go
+++ b/client/internal/netflow/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/netbirdio/netbird/client/internal/netflow/logger"
 	nftypes "github.com/netbirdio/netbird/client/internal/netflow/types"
 	"github.com/netbirdio/netbird/client/internal/peer"
+	"github.com/netbirdio/netbird/client/internal/statemanager"
 	"github.com/netbirdio/netbird/flow/client"
 	"github.com/netbirdio/netbird/flow/proto"
 )
@@ -33,12 +34,12 @@ type Manager struct {
 }
 
 // NewManager creates a new netflow manager
-func NewManager(iface nftypes.IFaceMapper, publicKey []byte, statusRecorder *peer.Status) *Manager {
+func NewManager(iface nftypes.IFaceMapper, publicKey []byte, statusRecorder *peer.Status, mgr *statemanager.Manager) *Manager {
 	var prefix netip.Prefix
 	if iface != nil {
 		prefix = iface.Address().Network
 	}
-	flowLogger := logger.New(statusRecorder, prefix)
+	flowLogger := logger.New(statusRecorder, prefix, mgr)
 
 	var ct nftypes.ConnTracker
 	if runtime.GOOS == "linux" && iface != nil && !iface.IsUserspaceBind() {

--- a/client/internal/netflow/manager_test.go
+++ b/client/internal/netflow/manager_test.go
@@ -41,7 +41,7 @@ func TestManager_Update(t *testing.T) {
 	publicKey := []byte("test-public-key")
 	statusRecorder := peer.NewRecorder("")
 
-	manager := NewManager(mockIFace, publicKey, statusRecorder)
+	manager := NewManager(mockIFace, publicKey, statusRecorder, nil)
 
 	tests := []struct {
 		name   string
@@ -105,7 +105,7 @@ func TestManager_Update_TokenPreservation(t *testing.T) {
 	}
 
 	publicKey := []byte("test-public-key")
-	manager := NewManager(mockIFace, publicKey, nil)
+	manager := NewManager(mockIFace, publicKey, nil, nil)
 
 	// First update with tokens
 	initialConfig := &types.FlowConfig{

--- a/client/internal/netflow/store/state.go
+++ b/client/internal/netflow/store/state.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netbirdio/netbird/client/internal/netflow/types"
+	"github.com/netbirdio/netbird/client/internal/statemanager"
+)
+
+const flowEventsStateName = "netflow_events"
+
+// flowEventsState represents persisted flow events in the state manager.
+type flowEventsState struct {
+	Events map[uuid.UUID]*types.Event `json:"events"`
+}
+
+func (s *flowEventsState) Name() string { return flowEventsStateName }
+
+type StateStore struct {
+	mux   sync.Mutex
+	mgr   *statemanager.Manager
+	state *flowEventsState
+}
+
+// NewStateStore creates a new store backed by the state manager.
+func NewStateStore(mgr *statemanager.Manager) (*StateStore, error) {
+	if mgr == nil {
+		return nil, fmt.Errorf("nil state manager")
+	}
+
+	st := &flowEventsState{}
+	mgr.RegisterState(st)
+	if err := mgr.LoadState(st); err != nil {
+		return nil, fmt.Errorf("load state: %w", err)
+	}
+
+	loaded := mgr.GetState(st)
+	if loaded != nil {
+		if loadedState, ok := loaded.(*flowEventsState); ok {
+			st = loadedState
+		}
+	}
+	if st.Events == nil {
+		st.Events = make(map[uuid.UUID]*types.Event)
+	}
+
+	return &StateStore{mgr: mgr, state: st}, nil
+}
+
+func (s *StateStore) StoreEvent(event *types.Event) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	s.state.Events[event.ID] = event
+	if err := s.mgr.UpdateState(s.state); err != nil {
+		log.Warnf("failed to persist flow event state: %v", err)
+	}
+}
+
+func (s *StateStore) GetEvents() []*types.Event {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	events := make([]*types.Event, 0, len(s.state.Events))
+	for _, e := range s.state.Events {
+		events = append(events, e)
+	}
+	return events
+}
+
+func (s *StateStore) DeleteEvents(ids []uuid.UUID) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	for _, id := range ids {
+		delete(s.state.Events, id)
+	}
+
+	if err := s.mgr.UpdateState(s.state); err != nil {
+		log.Warnf("failed to persist flow event state: %v", err)
+	}
+}
+
+func (s *StateStore) Close() {
+	// nothing to do
+}

--- a/management/server/grpcserver.go
+++ b/management/server/grpcserver.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	integrationsConfig "github.com/netbirdio/management-integrations/integrations/config"
 
@@ -622,11 +623,28 @@ func toNetbirdConfig(config *types.Config, turnCredentials *Token, relayToken *T
 		}
 	}
 
+	var flowCfg *proto.FlowConfig
+	if config.Flow != nil {
+		flowCfg = &proto.FlowConfig{
+			Url:            config.Flow.URL,
+			TokenPayload:   config.Flow.TokenPayload,
+			TokenSignature: config.Flow.TokenSignature,
+			Interval:       durationpb.New(config.Flow.Interval.Duration),
+		}
+		if extraSettings != nil {
+			flowCfg.Enabled = extraSettings.FlowEnabled
+			flowCfg.Counters = extraSettings.FlowPacketCounterEnabled
+			flowCfg.ExitNodeCollection = extraSettings.FlowENCollectionEnabled
+			flowCfg.DnsCollection = extraSettings.FlowDnsCollectionEnabled
+		}
+	}
+
 	nbConfig := &proto.NetbirdConfig{
 		Stuns:  stuns,
 		Turns:  turns,
 		Signal: signalCfg,
 		Relay:  relayCfg,
+		Flow:   flowCfg,
 	}
 
 	return nbConfig

--- a/management/server/testdata/management.json
+++ b/management/server/testdata/management.json
@@ -31,6 +31,12 @@
         "Username": "",
         "Password": null
     },
+    "Flow": {
+        "URL": "https://flow.netbird.io:443",
+        "Interval": "10s",
+        "TokenPayload": "",
+        "TokenSignature": ""
+    },
     "DataDir": "",
     "HttpConfig": {
         "LetsEncryptDomain": "<PASTE YOUR LET'S ENCRYPT DOMAIN HERE>",

--- a/management/server/types/config.go
+++ b/management/server/types/config.go
@@ -39,6 +39,8 @@ type Config struct {
 	Relay      *Relay
 	Signal     *Host
 
+	Flow *FlowServerConfig
+
 	Datadir                string
 	DataStoreEncryptionKey string
 
@@ -185,4 +187,12 @@ type ReverseProxy struct {
 	// request headers if the peer's address falls within one of these
 	// trusted IP prefixes.
 	TrustedPeers []netip.Prefix
+}
+
+// FlowServerConfig represents configuration for the traffic flow receiver
+type FlowServerConfig struct {
+	URL            string
+	TokenPayload   string
+	TokenSignature string
+	Interval       util.Duration
 }

--- a/management/server/types/settings.go
+++ b/management/server/types/settings.go
@@ -93,5 +93,9 @@ func (e *ExtraSettings) Copy() *ExtraSettings {
 	return &ExtraSettings{
 		PeerApprovalEnabled:       e.PeerApprovalEnabled,
 		IntegratedValidatorGroups: append(cpGroup, e.IntegratedValidatorGroups...),
+		FlowEnabled:               e.FlowEnabled,
+		FlowPacketCounterEnabled:  e.FlowPacketCounterEnabled,
+		FlowENCollectionEnabled:   e.FlowENCollectionEnabled,
+		FlowDnsCollectionEnabled:  e.FlowDnsCollectionEnabled,
 	}
 }


### PR DESCRIPTION
## Summary
- use state manager to persist flow events
- fall back to memory store if state manager not available
- propagate state manager to flow manager and logger

## Testing
- `go test ./...` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6843bd11c9b08324812111afff8f308b