### PR TITLE
Add simple traffic analytics aggregator

### DIFF
--- a/management/server/traffic/aggregator.go
+++ b/management/server/traffic/aggregator.go
@@ -1,0 +1,35 @@
+package traffic
+
+import api "github.com/netbirdio/netbird/management/server/http/api"
+
+// UserSummary holds aggregated traffic data per user.
+type UserSummary struct {
+	UserID    string
+	Email     string
+	RxBytes   int
+	TxBytes   int
+	RxPackets int
+	TxPackets int
+}
+
+// AggregateByUser calculates aggregated traffic statistics from a slice of
+// NetworkTrafficEvent. The returned map is keyed by user ID.
+func AggregateByUser(events []api.NetworkTrafficEvent) map[string]*UserSummary {
+	summary := make(map[string]*UserSummary)
+	for _, e := range events {
+		id := e.User.Id
+		if id == "" {
+			id = "unknown"
+		}
+		s, ok := summary[id]
+		if !ok {
+			s = &UserSummary{UserID: id, Email: e.User.Email}
+			summary[id] = s
+		}
+		s.RxBytes += e.RxBytes
+		s.TxBytes += e.TxBytes
+		s.RxPackets += e.RxPackets
+		s.TxPackets += e.TxPackets
+	}
+	return summary
+}

--- a/management/server/traffic/aggregator_test.go
+++ b/management/server/traffic/aggregator_test.go
@@ -1,0 +1,49 @@
+package traffic
+
+import (
+	"testing"
+
+	api "github.com/netbirdio/netbird/management/server/http/api"
+)
+
+func TestAggregateByUser(t *testing.T) {
+	events := []api.NetworkTrafficEvent{
+		{
+			User:      api.NetworkTrafficUser{Id: "u1", Email: "a@example.com"},
+			RxBytes:   100,
+			TxBytes:   50,
+			RxPackets: 10,
+			TxPackets: 5,
+		},
+		{
+			User:      api.NetworkTrafficUser{Id: "u1", Email: "a@example.com"},
+			RxBytes:   200,
+			TxBytes:   100,
+			RxPackets: 20,
+			TxPackets: 10,
+		},
+		{
+			User:      api.NetworkTrafficUser{Id: "u2", Email: "b@example.com"},
+			RxBytes:   300,
+			TxBytes:   150,
+			RxPackets: 30,
+			TxPackets: 15,
+		},
+	}
+
+	got := AggregateByUser(events)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(got))
+	}
+
+	u1 := got["u1"]
+	if u1 == nil || u1.RxBytes != 300 || u1.TxBytes != 150 || u1.RxPackets != 30 || u1.TxPackets != 15 {
+		t.Errorf("unexpected stats for u1: %+v", u1)
+	}
+
+	u2 := got["u2"]
+	if u2 == nil || u2.RxBytes != 300 || u2.TxBytes != 150 || u2.RxPackets != 30 || u2.TxPackets != 15 {
+		t.Errorf("unexpected stats for u2: %+v", u2)
+	}
+}


### PR DESCRIPTION
## Summary
- add traffic aggregator package with `AggregateByUser`
- provide unit test for aggregator

## Testing
- `go test ./management/server/traffic -run TestAggregateByUser -v`


------
https://chatgpt.com/codex/tasks/task_e_684410ad7dfc832495b202542b82822a