### PR TITLE
Fix integration metrics alias

### DIFF
--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -161,7 +161,7 @@ var (
 				return err
 			}
 
-			integrationMetrics, err := integrations.InitIntegrationMetrics(ctx, appMetrics)
+			integrationMetrics, err := extintegrations.InitIntegrationMetrics(ctx, appMetrics)
 			if err != nil {
 				return err
 			}
@@ -183,7 +183,7 @@ var (
 			if disableSingleAccMode {
 				mgmtSingleAccModeDomain = ""
 			}
-			eventStore, key, err := integrations.InitEventStore(ctx, config.Datadir, config.DataStoreEncryptionKey, integrationMetrics)
+			eventStore, key, err := extintegrations.InitEventStore(ctx, config.Datadir, config.DataStoreEncryptionKey, integrationMetrics)
 			if err != nil {
 				return fmt.Errorf("failed to initialize database: %s", err)
 			}


### PR DESCRIPTION
## Summary
- fix function calls to use the `extintegrations` alias in `management/cmd/management.go`

## Testing
- `CGO_ENABLED=1 go build ./management/cmd`

------
https://chatgpt.com/codex/tasks/task_b_686233eaa98c8325bb0a815233410641