### PR TITLE
Fix OnPeerDisconnected mock

### DIFF
--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -139,9 +139,8 @@ func (am *MockAccountManager) SyncAndMarkPeer(ctx context.Context, accountID str
 	return nil, nil, nil, status.Errorf(codes.Unimplemented, "method MarkPeerConnected is not implemented")
 }
 
-func (am *MockAccountManager) OnPeerDisconnected(_ context.Context, accountID string, peerPubKey string) error {
-	// TODO implement me
-	panic("implement me")
+func (am *MockAccountManager) OnPeerDisconnected(ctx context.Context, accountID string, peerPubKey string) error {
+	return am.MarkPeerConnected(ctx, peerPubKey, false, nil, accountID)
 }
 
 func (am *MockAccountManager) GetValidatedPeers(ctx context.Context, accountID string) (map[string]struct{}, error) {


### PR DESCRIPTION
## Summary
- implement `OnPeerDisconnected` in MockAccountManager

## Testing
- `go vet ./...` *(fails: Get https://storage.googleapis.com/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6862372d97008325b580a6db5d61c7b7