### PR TITLE
Fix container mount path for client tests

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -188,7 +188,7 @@ jobs:
           docker run --rm \
             --cap-add=NET_ADMIN \
             --privileged \
-            -v $PWD:/app \
+            -v "$(pwd)":/app \
             -w /app \
             -v "${HOST_GOCACHE}:${CONTAINER_GOCACHE}" \
             -v "${HOST_GOMODCACHE}:${CONTAINER_GOMODCACHE}" \


### PR DESCRIPTION
## Summary
- ensure the test container mounts the repository using `$(pwd)`

## Testing
- `go vet ./...` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68623c5ce92483259d2e7c6e7a937795