### PR TITLE
Fix Docker network creation in tests

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -438,7 +438,7 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
       - name: Create Docker network
-        run: docker network create promnet
+        run: docker network inspect promnet >/dev/null 2>&1 || docker network create promnet
 
       - name: Start Prometheus Pushgateway
         run: docker run -d --name pushgateway --network promnet -p 9091:9091 prom/pushgateway


### PR DESCRIPTION
## Summary
- avoid failing if `promnet` already exists during docker network creation

## Testing
- `go test ./...` *(fails: `X11/Xcursor/Xcursor.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_68623c7307bc8325866bcf22ef4e4966