### PR TITLE
Fix ephemeral manager cleanup

### DIFF
--- a/management/server/management_proto_test.go
+++ b/management/server/management_proto_test.go
@@ -466,7 +466,13 @@ func startManagementForTest(t *testing.T, testFile string, config *types.Config)
 		}
 	}()
 
-	return s, accountManager, lis.Addr().String(), cleanup, nil
+	// extend cleanup to stop the ephemeral manager before removing the database
+	cleanupFn := func() {
+		ephemeralMgr.Stop()
+		cleanup()
+	}
+
+	return s, accountManager, lis.Addr().String(), cleanupFn, nil
 }
 
 func createRawClient(addr string) (mgmtProto.ManagementServiceClient, *grpc.ClientConn, error) {


### PR DESCRIPTION
## Summary
- stop EphemeralManager timers during test teardown

## Testing
- `go test ./management/server -run TestNewManager -count=1 -timeout=60s` *(fails: context deadline exceeded)*

------
https://chatgpt.com/codex/tasks/task_b_68624b91eb5c8325b685eb341d822312