### PR TITLE
Fix codespell step

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,11 +16,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: codespell
-        uses: codespell-project/actions-codespell@v2
-        with:
-          ignore_words_list: erro,clienta,hastable,iif,groupd,testin,groupe
-          skip: go.mod,go.sum
+      - name: Install codespell
+        run: pip install codespell
+      - name: Run codespell
+        run: |
+          python -m codespell --skip "go.mod,go.sum" \
+            --ignore-words-list "erro,clienta,hastable,iif,groupd,testin,groupe" .
   golangci:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- modify lint workflow to install and invoke codespell via python module

## Testing
- `pip install codespell`
- `codespell --skip "go.mod,go.sum" --ignore-words-list "erro,clienta,hastable,iif,groupd,testin,groupe" .`
- `go test ./base62 -run Test`


------
https://chatgpt.com/codex/tasks/task_b_68625085520c83258e264bb4c7784e9f