### PR TITLE
Fix codespell GitHub action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,12 +16,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install codespell
-        run: pip install codespell
       - name: codespell
-        run: |
-          codespell --skip "go.mod,go.sum" \
-            --ignore-words-list "erro,clienta,hastable,iif,groupd,testin,groupe" .
+        uses: codespell-project/actions-codespell@v2
+        with:
+          skip: go.mod,go.sum
+          ignore_words_list: erro,clienta,hastable,iif,groupd,testin,groupe
   golangci:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- fix `codespell` workflow step by using the official Codespell action

## Testing
- `go test ./...` *(fails: gcc: signal: interrupt)*

------
https://chatgpt.com/codex/tasks/task_b_686261c587188325b224a2d7e434b2d6