### PR TITLE
Fix dpkg configuration in Signal tests

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -19,7 +19,6 @@ jobs:
     steps:        
       - name: Checkout code
         uses: actions/checkout@v4
-
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -223,6 +222,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Fix interrupted apt
+        run: sudo dpkg --configure -a
+
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: sudo apt update && sudo apt install -y gcc-multilib g++-multilib libc6-dev-i386
@@ -272,6 +274,9 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Fix interrupted apt
+        run: sudo dpkg --configure -a
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- remove stray blank line in build-cache job
- ensure Signal unit tests run `sudo dpkg --configure -a` before installing packages

## Testing
- `go test ./signal/... -run '' -count=1`


------
https://chatgpt.com/codex/tasks/task_b_68627cb03c5c83258521e9c6830738d1